### PR TITLE
Enabled Rolling, Walljumping With Weapons

### DIFF
--- a/codemp/game/bg_pmove.c
+++ b/codemp/game/bg_pmove.c
@@ -2086,7 +2086,7 @@ static qboolean PM_CheckJump( void )
 	else if ( pm->cmd.upmove > 0 && pm->waterlevel < 2 &&
 		pm->ps->fd.forcePowerLevel[FP_LEVITATION] > FORCE_LEVEL_0 &&
 		!(pm->ps->pm_flags&PMF_JUMP_HELD) &&
-		(pm->ps->weapon == WP_SABER || pm->ps->weapon == WP_MELEE) &&
+//		(pm->ps->weapon == WP_SABER || pm->ps->weapon == WP_MELEE) &&
 		!PM_IsRocketTrooper() &&
 		!BG_HasYsalamiri(pm->gametype, pm->ps) &&
 		BG_CanUseFPNow(pm->gametype, pm->ps, pm->cmd.serverTime, FP_LEVITATION) )
@@ -3583,8 +3583,8 @@ static int PM_TryRoll( void )
 		}
 	}
 
-	if ((pm->ps->weapon != WP_SABER && pm->ps->weapon != WP_MELEE) ||
-		PM_IsRocketTrooper() ||
+	if (PM_IsRocketTrooper() ||		
+//		(pm->ps->weapon != WP_SABER && pm->ps->weapon != WP_MELEE) ||
 		BG_HasYsalamiri(pm->gametype, pm->ps) ||
 		!BG_CanUseFPNow(pm->gametype, pm->ps, pm->cmd.serverTime, FP_LEVITATION))
 	{ //Not using saber, or can't use jump


### PR DESCRIPTION
enabled rolling and walljumping while the player is holding a weapon (by
commenting out the relevant checks in the if statements)